### PR TITLE
Feature/parse direct declarator

### DIFF
--- a/src/calc/ast.rs
+++ b/src/calc/ast.rs
@@ -1,6 +1,5 @@
 /// 関数定義を表す
 /// <function-definition> ::= {<declaration-specifier>}* <declarator> {<declaration>}* <compound-statement>
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct FunctionDefinitionParser {
     type_specifier: TypeSpecifier,
@@ -28,8 +27,37 @@ impl FunctionDefinitionParser {
     }
 }
 
+/// Declarattor
+#[derive(Debug, PartialEq, Clone)]
+pub struct Declarator {
+    //pointer: Pointer,
+    direct_declarator: Expr,
+}
+
+impl Declarator {
+    pub fn new(val: Expr) -> Declarator {
+        Declarator {
+            direct_declarator: val,
+        }
+    }
+    /// Declaratorを評価する
+    pub fn eval(&self) -> Declarator {
+        self.clone()
+    }
+}
+/*
+/// DirectDeclarattor
+#[derive(Debug, PartialEq, Clone)]
+pub struct DirectDeclarattor {
+    identifer: Identifier,
+}
+impl DirectDeclarator {
+    pub fn new(identifer: Box<Identifier>, declarator: Box<DirectDeclarattor>) -> DirectDeclarator {
+    }
+}
+*/
+
 /// 複合ステートメントを表す
-/// BNF =>
 /// statement := <labeled-statement>
 ///           | <expression-statement> | <compound-statement>
 ///           | <selection-statement>
@@ -58,7 +86,7 @@ impl ExprStatement {
 }
 
 /// 式ステートメントを表す
-/// BNF => expression-statement ::= {<expression>}? ;
+/// expression-statement ::= {<expression>}? ;
 #[derive(Debug, PartialEq, Clone)]
 pub struct Statement {
     stmt: Expr,
@@ -74,7 +102,8 @@ impl Statement {
 /// 任意の式を表す
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expr {
-    FunctionDefinitionParser(Box<Vec<Expr>>, Box<Expr>, Box<Expr>),
+    FunctionDefinitionParser(Box<Vec<Expr>>, Box<Vec<Expr>>, Box<Expr>),
+    Declarator(Box<Expr>),
     TypeSpecifier(TypeSpecifier),
     Identifier(Identifier),
     ConstantVal(ConstantVal),

--- a/src/calc/ast.rs
+++ b/src/calc/ast.rs
@@ -40,6 +40,11 @@ impl Declarator {
             direct_declarator: Box::new(val),
         }
     }
+    pub fn dummy() -> Declarator {
+        Declarator {
+            direct_declarator: Box::new(Expr::Eof(Eof::new())),
+        }
+    }
     /// Declaratorを評価する
     pub fn eval(&self) -> Declarator {
         self.clone()

--- a/src/calc/ast.rs
+++ b/src/calc/ast.rs
@@ -31,13 +31,13 @@ impl FunctionDefinitionParser {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Declarator {
     //pointer: Pointer,
-    direct_declarator: Expr,
+    direct_declarator: Box<Expr>,
 }
 
 impl Declarator {
     pub fn new(val: Expr) -> Declarator {
         Declarator {
-            direct_declarator: val,
+            direct_declarator: Box::new(val),
         }
     }
     /// Declaratorを評価する
@@ -85,6 +85,35 @@ impl ExprStatement {
     }
 }
 
+/// 引数リストを表す
+/// expression-statement ::= {<expression>}? ;
+#[derive(Debug, PartialEq, Clone)]
+pub struct ParameterTypeList {
+    parameter: Vec<Expr>,
+}
+
+impl ParameterTypeList {
+    pub fn new(val: Vec<Expr>) -> ParameterTypeList {
+        ParameterTypeList { parameter: val }
+    }
+}
+
+/// 型+変数を表す
+#[derive(Debug, PartialEq, Clone)]
+pub struct ParameterDeclaration {
+    declaration_specifier: Vec<Expr>,
+    declarator: Declarator,
+}
+
+impl ParameterDeclaration {
+    pub fn new(ds: Vec<Expr>, d: Declarator) -> ParameterDeclaration {
+        ParameterDeclaration {
+            declaration_specifier: ds,
+            declarator: d,
+        }
+    }
+}
+
 /// 式ステートメントを表す
 /// expression-statement ::= {<expression>}? ;
 #[derive(Debug, PartialEq, Clone)]
@@ -103,6 +132,8 @@ impl Statement {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expr {
     FunctionDefinitionParser(Box<Vec<Expr>>, Box<Vec<Expr>>, Box<Expr>),
+    ParameterTypeList(ParameterTypeList),
+    ParameterDeclaration(Vec<Expr>, Declarator),
     Declarator(Box<Expr>),
     TypeSpecifier(TypeSpecifier),
     Identifier(Identifier),

--- a/src/calc/parser.rs
+++ b/src/calc/parser.rs
@@ -159,21 +159,26 @@ pub fn parameter_type_list(s: &str) -> IResult<&str, Expr> {
 /// <parameter-list> ::= <parameter-declaration>
 ///                    | <parameter-list> , <parameter-declaration>
 pub fn parameter_list(s: &str) -> IResult<&str, Expr> {
-    let result = tuple((parameter_delaration, opt(char(','))));
+    let result = tuple((parameter_declaration, opt(char(','))));
     map(result, |(head_expr, _)| head_expr)(s)
 }
 
 /// <parameter-declaration> ::= {<declaration-specifier>}+ <declarator>
 ///                           | {<declaration-specifier>}+ <abstract-declarator>
 ///                           | {<declaration-specifier>}+
-pub fn parameter_delaration(s: &str) -> IResult<&str, Expr> {
-    declaration_specifier_parser(s)
+pub fn parameter_declaration(s: &str) -> IResult<&str, Expr> {
+    let parser = tuple((many1(declaration_specifier_parser), opt(declarator_parser)));
+
+    map(parser, |(dsp, dp_apt)| {
+        if let Option::Some(dp) = dp_apt {
+            Expr::ParameterDeclaration(dsp, Declarator::new(dp))
+        } else {
+            Expr::ParameterDeclaration(dsp, Declarator::dummy())
+        }
+    })(s)
     /*
         let parser = tuple((many1(declaration_specifier_parser), declarator_parser));
 
-        map(parser, |(dsp, dp)| {
-            Expr::ParameterDeclaration(dsp, Box::new(dp))
-        })(s)
     */
 }
 


### PR DESCRIPTION
# 関数定義の際などに使われる複数引数の羅列をパースさせる実装

## 実装
 
- 以下の文をParse可能

```
int main(void, int) {12;}
```
- 変数名の処理はまだできてない、、、すまん；；

## 不具合等
- スペースとかカンマとかを処理する部分の詰めが甘いので `int main(char char char) {12;}`とかも警告なしで動く（しかも正しい動きじゃない）
- 処理のシステム的に`int void main`が行けちゃう（相反する型が宣言可能）