### PR TITLE
Return文を解析する実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,10 +33,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "backtrace-on-stack-overflow"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd2d70527f3737a1ad17355e260706c1badebabd1fa06a7a053407380df841b"
+dependencies = [
+ "backtrace",
+ "libc",
+ "nix",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -30,9 +86,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "kanini"
 version = "0.1.0"
 dependencies = [
+ "backtrace-on-stack-overflow",
  "nom",
  "regex",
 ]
@@ -51,10 +114,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nom"
@@ -65,6 +165,15 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "object"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -97,10 +206,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "static_assertions"
@@ -113,3 +234,67 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 regex = "1.10.6"
 nom="5"
+backtrace-on-stack-overflow = "0.3.0"

--- a/src/calc/ast.rs
+++ b/src/calc/ast.rs
@@ -1,32 +1,3 @@
-/// 関数定義を表す
-/// <function-definition> ::= {<declaration-specifier>}* <declarator> {<declaration>}* <compound-statement>
-#[derive(Debug, PartialEq, Clone)]
-pub struct FunctionDefinitionParser {
-    type_specifier: TypeSpecifier,
-    declarator: Identifier,
-    expr_stmt: ExprStatement,
-}
-
-impl FunctionDefinitionParser {
-    /// 生成する
-    pub fn new(
-        type_specifier: TypeSpecifier,
-        declarator: Identifier,
-        expr_stmt: ExprStatement,
-    ) -> FunctionDefinitionParser {
-        FunctionDefinitionParser {
-            type_specifier,
-            declarator,
-            expr_stmt,
-        }
-    }
-
-    /// 関数を評価する
-    pub fn eval(&self) -> FunctionDefinitionParser {
-        self.clone()
-    }
-}
-
 /// Declarattor
 #[derive(Debug, PartialEq, Clone)]
 pub struct Declarator {
@@ -50,6 +21,52 @@ impl Declarator {
         self.clone()
     }
 }
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct DirectDeclarator {
+    identifer: Box<Expr>,
+    declarator: Box<Expr>,
+    direct_declarator: Box<Expr>,
+}
+
+impl DirectDeclarator {
+    /// <direct-declarator> ::= <identifier>
+    ///                       | ( <declarator> )
+    ///                       | <direct-declarator> [ {<constant-expression>}? ]
+    ///                       | <direct-declarator> ( <parameter-type-list> )
+    ///                       | <direct-declarator> ( {<identifier>}* )
+    pub fn identifier(identifier: Expr) -> DirectDeclarator {
+        DirectDeclarator {
+            identifer: Box::new(identifier),
+            declarator: Box::new(Expr::Eof(Eof::new())),
+            direct_declarator: Box::new(Expr::Eof(Eof::new())),
+        }
+    }
+
+    pub fn declarator(declarator: Expr) -> DirectDeclarator {
+        DirectDeclarator {
+            declarator: Box::new(declarator),
+            identifer: Box::new(Expr::Eof(Eof::new())),
+            direct_declarator: Box::new(Expr::Eof(Eof::new())),
+        }
+    }
+
+    pub fn directdeclarator_identifier(
+        directdeclarator: Expr,
+        identifier: Expr,
+    ) -> DirectDeclarator {
+        DirectDeclarator {
+            direct_declarator: Box::new(directdeclarator),
+            identifer: Box::new(identifier),
+            declarator: Box::new(Expr::Eof(Eof::new())),
+        }
+    }
+    /// Declaratorを評価する
+    pub fn eval(&self) -> DirectDeclarator {
+        self.clone()
+    }
+}
+
 /*
 /// DirectDeclarattor
 #[derive(Debug, PartialEq, Clone)]
@@ -133,12 +150,42 @@ impl Statement {
     }
 }
 
+/// 関数定義を表す
+/// <function-definition> ::= {<declaration-specifier>}* <declarator> {<declaration>}* <compound-statement>
+#[derive(Debug, PartialEq, Clone)]
+pub struct FunctionDefinitionParser {
+    type_specifier: TypeSpecifier,
+    declarator: Identifier,
+    expr_stmt: ExprStatement,
+}
+
+impl FunctionDefinitionParser {
+    /// 生成する
+    pub fn new(
+        type_specifier: TypeSpecifier,
+        declarator: Identifier,
+        expr_stmt: ExprStatement,
+    ) -> FunctionDefinitionParser {
+        FunctionDefinitionParser {
+            type_specifier,
+            declarator,
+            expr_stmt,
+        }
+    }
+
+    /// 関数を評価する
+    pub fn eval(&self) -> FunctionDefinitionParser {
+        self.clone()
+    }
+}
+
 /// 任意の式を表す
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expr {
-    FunctionDefinitionParser(Box<Vec<Expr>>, Box<Vec<Expr>>, Box<Expr>),
+    FunctionDefinitionParser(Vec<Expr>, Box<Expr>, Box<Expr>),
     ParameterTypeList(ParameterTypeList),
     ParameterDeclaration(Vec<Expr>, Declarator),
+    DirectDeclarator(DirectDeclarator),
     Declarator(Box<Expr>),
     TypeSpecifier(TypeSpecifier),
     Identifier(Identifier),

--- a/src/calc/ast.rs
+++ b/src/calc/ast.rs
@@ -27,6 +27,7 @@ pub struct DirectDeclarator {
     identifer: Box<Expr>,
     declarator: Box<Expr>,
     direct_declarator: Box<Expr>,
+    parameter_type_list: Option<Box<Expr>>,
 }
 
 impl DirectDeclarator {
@@ -40,6 +41,7 @@ impl DirectDeclarator {
             identifer: Box::new(identifier),
             declarator: Box::new(Expr::Eof(Eof::new())),
             direct_declarator: Box::new(Expr::Eof(Eof::new())),
+            parameter_type_list: None,
         }
     }
 
@@ -48,6 +50,7 @@ impl DirectDeclarator {
             declarator: Box::new(declarator),
             identifer: Box::new(Expr::Eof(Eof::new())),
             direct_declarator: Box::new(Expr::Eof(Eof::new())),
+            parameter_type_list: None,
         }
     }
 
@@ -59,6 +62,19 @@ impl DirectDeclarator {
             direct_declarator: Box::new(directdeclarator),
             identifer: Box::new(identifier),
             declarator: Box::new(Expr::Eof(Eof::new())),
+            parameter_type_list: None,
+        }
+    }
+
+    pub fn directdeclarator_parametertypelist(
+        identifier: Expr,
+        parameter_type_list: Expr,
+    ) -> DirectDeclarator {
+        DirectDeclarator {
+            direct_declarator: Box::new(Expr::Eof(Eof::new())),
+            identifer: Box::new(identifier),
+            declarator: Box::new(Expr::Eof(Eof::new())),
+            parameter_type_list: Some(Box::new(parameter_type_list)),
         }
     }
     /// Declaratorを評価する
@@ -140,13 +156,17 @@ impl ParameterDeclaration {
 /// expression-statement ::= {<expression>}? ;
 #[derive(Debug, PartialEq, Clone)]
 pub struct Statement {
+    hoge: String,
     stmt: Expr,
 }
 
 impl Statement {
     /// ConstantVal init
     pub fn new(val: Expr) -> Statement {
-        Statement { stmt: val }
+        Statement {
+            hoge: String::from("hoge"),
+            stmt: val,
+        }
     }
 }
 
@@ -193,6 +213,7 @@ pub enum Expr {
     BinaryOp(Box<BinaryOp>),
     ExprStatement(Vec<Expr>),
     Statement(Box<Expr>),
+    Return(Vec<Expr>),
     Eof(Eof),
 }
 
@@ -204,6 +225,25 @@ impl Expr {
             Expr::ConstantVal(e) => e.eval(),
             Expr::BinaryOp(e) => e.eval(),
             _ => 0,
+        }
+    }
+}
+
+/// return
+#[derive(Debug, PartialEq, Clone)]
+
+pub struct Return {
+    statement: Statement,
+    foo1: i32,
+    foo2: i64,
+}
+
+impl Return {
+    pub fn new(val: Statement, hoge1: i32, hoge2: i64) -> Return {
+        Return {
+            statement: val,
+            foo1: hoge1,
+            foo2: hoge2,
         }
     }
 }

--- a/src/calc/parser.rs
+++ b/src/calc/parser.rs
@@ -128,51 +128,33 @@ pub fn declarator_parser(s: &str) -> IResult<&str, Expr> {
 /// 直接宣言者のパーサ
 /// <direct-declarator> ::= <identifier>
 ///                       | ( <declarator> )
-///                       | <direct-declarator> [ {<constant-expression>}? ]
 ///                       | <direct-declarator> ( <parameter-type-list> )
+///                       | <direct-declarator> [ {<constant-expression>}? ]
 ///                       | <direct-declarator> ( {<identifier>}* )
 pub fn direct_declarator(s: &str) -> IResult<&str, Expr> {
+    let directdeclarator_declarator = tuple((tag("("), declarator_parser, tag(")")));
+    println!("{}", s);
+
+    let directdeclarator_parametertypelist = tuple((identifier_parser, char('('), char(')')));
+    /*
+    let directdeclarator_parametertypelist =
+        tuple((identifier_parser, char('('), parameter_type_list, char(')')));
+
+    */
+
     let identifer = identifier_parser;
-
-    let directdeclarator_declarator = tuple((
-        /*direct_declarator,*/ tag("("),
-        declarator_parser,
-        tag(")"),
-    ));
-
-    let directdeclarator_parametertypelist = tuple((
-        /*direct_declarator,*/ tag("("),
-        parameter_type_list,
-        tag(")"),
-    ));
-
-    let directdeclarator_identifier = tuple((
-        /*direct_declarator,*/
-        tag("("),
-        many0(identifier_parser),
-        tag(")"),
-    ));
+    //let directdeclarator_identifier = tuple((tag("("), many0(identifier_parser), tag(")")));
 
     alt((
-        map(identifer, |i| {
-            println!("{:?}", i);
-            i
-        }),
-        map(directdeclarator_declarator, |dd| {
-            println!("{:?}", dd);
-            dd.1
-        }),
-        map(directdeclarator_parametertypelist, |dp| {
-            println!("{:?}", dp);
-            dp.1
-        }),
-        map(directdeclarator_identifier, |di| {
-            println!("{:?}", di);
-            return Expr::Identifier(Identifier::new(String::from("OK")));
-        }),
+        map(identifer, |i| i),
+        map(directdeclarator_declarator, |dd| dd.1),
+        map(directdeclarator_parametertypelist, |dp| dp.0),
     ))(s)
 
     /*
+
+
+
     alt((
         map(identifier_parser, |identifer| {
             println!("{:?}", identifer);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,6 @@ use crate::calc::expr_eval;
 
 use std::io::Write;
 
-fn sub_main() {}
-
 fn main() {
     unsafe { backtrace_on_stack_overflow::enable() };
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ pub mod calc;
 use crate::calc::expr_eval;
 
 use std::io::Write;
+
+fn sub_main() {}
+
 fn main() {
     unsafe { backtrace_on_stack_overflow::enable() };
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use crate::calc::expr_eval;
 
 use std::io::Write;
 fn main() {
+    unsafe { backtrace_on_stack_overflow::enable() };
     loop {
         print!("> ");
         std::io::stdout().flush().unwrap();


### PR DESCRIPTION
# Return文を解析する実装
 
Return文を解析するために構文解析のシステムを一部変更。

## 実装
以下の文を解析可能。
`int main(int n, void) {return 12;}`

return句をパースするためにjump_statmentを実装。

## 不具合等

特になしだが、強いて言えば出力されるASTがﾁｮｯﾄ見にくい