### PR TITLE
ファイルからデータを読み込んでパースする実装

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,19 +21,34 @@ fn interpreter() -> Result<(), String> {
     // -----------------
 }
 
-fn main() {
+fn command_parse() -> Result<(), String> {
     // コマンド引数を取得
     let args: Vec<String> = std::env::args().collect();
-    let mode = args[1].as_str();
+    if args.len() > 1 {
+        let mode = args[1].as_str();
 
-    match mode {
-        "-i" => loop {
-            interpreter();
-        },
-        _ => {
-            println!("ファイル内実行モード");
+        match mode {
+            "-i" => loop {
+                let _ = match interpreter() {
+                    Ok(()) => (),
+                    Err(e) => println!("!ERROR!: {}", e),
+                };
+            },
+            _ => {
+                println!("ファイル内実行モード");
+                return Err("ファイルが見つかりません".to_string());
+            }
         }
+    } else {
+        println!("kanini ver 0.1");
     }
+    Ok(())
+}
+
+fn main() {
     // スタックオーバーフローの際の原因特定
     unsafe { backtrace_on_stack_overflow::enable() };
+
+    // TODO: エラーの際の実装
+    let _ = command_parse();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,20 +29,18 @@ fn interpreter() -> Result<(), String> {
 
 fn read_file(filename: &str) -> Result<(), String> {
     // ファイル読み込み→実行モード
-    // ファイルが見つかりませんでした
-    let mut f = match File::open(filename) {
-        Err(e) => return Err(e.to_string()),
-        Ok(value) => value,
-    };
-
-    let mut contents = String::new();
-    if let Ok((r)) = f.read_to_string(&mut contents) {
-    } else {
-        // ファイルの読み込み中に問題がありました
-        return Err("something went wrong reading the file".to_string());
+    match File::open(filename) {
+        Ok(mut value) => {
+            let mut contents = String::new();
+            match value.read_to_string(&mut contents) {
+                Ok(_) => eval(&contents.as_str()),
+                // ファイルの読み込み中に問題がありました
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        // ファイルが見つかりませんでした
+        Err(e) => Err(e.to_string()),
     }
-
-    eval(&contents.as_str())
 }
 
 fn command_parse() -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,16 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::Write;
 
+fn eval(expr: &str) -> Result<(), String> {
+    let value = match expr_eval(&expr) {
+        Ok(value) => value,
+        _ => return Err("構文エラー".to_string()),
+    };
+    println!("{:?}", value);
+
+    Ok(())
+}
+
 fn interpreter() -> Result<(), String> {
     // インタプリタモード
     print!("> ");
@@ -13,34 +23,26 @@ fn interpreter() -> Result<(), String> {
 
     let mut s = String::new();
     std::io::stdin().read_line(&mut s).ok();
-    let value = match expr_eval(&s) {
-        Ok(value) => value,
-        _ => return Err("構文エラー".to_string()),
-    };
-    println!("{:?}", value);
 
-    Ok(())
-    // -----------------
+    eval(&s)
 }
 
 fn read_file(filename: &str) -> Result<(), String> {
+    // ファイル読み込み→実行モード
     // ファイルが見つかりませんでした
     let mut f = match File::open(filename) {
         Err(e) => return Err(e.to_string()),
         Ok(value) => value,
-    }; //.expect("file not found");
-    let mut contents = String::new();
-    f.read_to_string(&mut contents)
-        // ファイルの読み込み中に問題がありました
-        .expect("something went wrong reading the file");
-
-    let value = match expr_eval(&contents.as_str()) {
-        Ok(value) => value,
-        _ => return Err("構文エラー".to_string()),
     };
 
-    println!("{:?}", value);
-    Ok(())
+    let mut contents = String::new();
+    if let Ok((r)) = f.read_to_string(&mut contents) {
+    } else {
+        // ファイルの読み込み中に問題がありました
+        return Err("something went wrong reading the file".to_string());
+    }
+
+    eval(&contents.as_str())
 }
 
 fn command_parse() -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,36 @@ use crate::calc::expr_eval;
 
 use std::io::Write;
 
-fn main() {
-    unsafe { backtrace_on_stack_overflow::enable() };
-    loop {
-        print!("> ");
-        std::io::stdout().flush().unwrap();
+fn interpreter() -> Result<(), String> {
+    // インタプリタモード
+    print!("> ");
+    std::io::stdout().flush().unwrap();
 
-        let mut s = String::new();
-        std::io::stdin().read_line(&mut s).ok();
-        match expr_eval(&s) {
-            Ok(val) => println!("OK: {:?}", val),
-            _ => println!("構文に誤りがあります"),
+    let mut s = String::new();
+    std::io::stdin().read_line(&mut s).ok();
+    let value = match expr_eval(&s) {
+        Ok(value) => value,
+        _ => return Err("構文エラー".to_string()),
+    };
+    println!("{:?}", value);
+
+    Ok(())
+    // -----------------
+}
+
+fn main() {
+    // コマンド引数を取得
+    let args: Vec<String> = std::env::args().collect();
+    let mode = args[1].as_str();
+
+    match mode {
+        "-i" => loop {
+            interpreter();
+        },
+        _ => {
+            println!("ファイル内実行モード");
         }
     }
+    // スタックオーバーフローの際の原因特定
+    unsafe { backtrace_on_stack_overflow::enable() };
 }
-// Ok(val) => println!("{}", val),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ pub mod calc;
 
 use crate::calc::expr_eval;
 
+use std::fs::File;
+use std::io::prelude::*;
 use std::io::Write;
 
 fn interpreter() -> Result<(), String> {
@@ -21,6 +23,26 @@ fn interpreter() -> Result<(), String> {
     // -----------------
 }
 
+fn read_file(filename: &str) -> Result<(), String> {
+    // ファイルが見つかりませんでした
+    let mut f = match File::open(filename) {
+        Err(e) => return Err(e.to_string()),
+        Ok(value) => value,
+    }; //.expect("file not found");
+    let mut contents = String::new();
+    f.read_to_string(&mut contents)
+        // ファイルの読み込み中に問題がありました
+        .expect("something went wrong reading the file");
+
+    let value = match expr_eval(&contents.as_str()) {
+        Ok(value) => value,
+        _ => return Err("構文エラー".to_string()),
+    };
+
+    println!("{:?}", value);
+    Ok(())
+}
+
 fn command_parse() -> Result<(), String> {
     // コマンド引数を取得
     let args: Vec<String> = std::env::args().collect();
@@ -36,7 +58,11 @@ fn command_parse() -> Result<(), String> {
             },
             _ => {
                 println!("ファイル内実行モード");
-                return Err("ファイルが見つかりません".to_string());
+
+                let _ = match read_file(mode) {
+                    Ok(()) => (),
+                    Err(e) => println!("!ERROR!: {}", e),
+                };
             }
         }
     } else {


### PR DESCRIPTION
# ファイルからデータを読み込んでパースする実装

だいぶ前から作るのを渋っていたファイルからの読み込みをとりあえず実装！
エラー処理とかもまとめて結構いい感じに処理しておきました。
あと、改行とか空白とかを誤検知してエラーになったのでまとめてMultispace0に改善。

## 実装

以下のコードでそれぞれ実行。

- インタプリタモード
`cargo run -- -i`

- ファイル読み込みモード
`cargo run -- test.c`