### PR TITLE
ADD: クオートで囲った文字列のパースに対応

### DIFF
--- a/src/calc/ast.rs
+++ b/src/calc/ast.rs
@@ -210,6 +210,7 @@ pub enum Expr {
     TypeSpecifier(TypeSpecifier),
     Identifier(Identifier),
     ConstantVal(ConstantVal),
+    StringVal(String),
     BinaryOp(Box<BinaryOp>),
     ExprStatement(Vec<Expr>),
     Statement(Box<Expr>),
@@ -400,6 +401,22 @@ impl ConstantVal {
 }
 
 /// 文字列を表す
+#[derive(Debug, PartialEq, Clone)]
+pub struct StringVal(String);
+
+impl StringVal {
+    /// StringVal init
+    pub fn new(val: String) -> StringVal {
+        StringVal(val)
+    }
+
+    /// StringValの値を取得
+    pub fn eval(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// 任意トークンを表す
 #[derive(Debug, PartialEq, Clone)]
 pub struct Identifier(String);
 

--- a/src/calc/parser.rs
+++ b/src/calc/parser.rs
@@ -1,21 +1,15 @@
-use std::ops::Mul;
-
 use super::ast::*;
 use nom::branch::alt;
 use nom::branch::permutation;
-use nom::bytes::complete::is_a;
 use nom::bytes::complete::tag;
-use nom::character::complete::alpha0;
 use nom::character::complete::alpha1;
 use nom::character::complete::char;
 use nom::character::complete::digit1;
 use nom::character::complete::multispace0;
 use nom::combinator::map;
 use nom::combinator::opt;
-use nom::combinator::recognize;
 use nom::multi::many0;
 use nom::multi::many1;
-use nom::sequence::pair;
 use nom::sequence::tuple;
 use nom::IResult;
 
@@ -406,40 +400,10 @@ pub fn constant_val_parser(s: &str) -> IResult<&str, ConstantVal> {
     Ok((no_used, ConstantVal::new(val)))
 }
 
-/*
-    map(i, |(&alpha, opt_underbar)| {
-                if let Option::Some(underbar) = opt_underbar {
-                    if alpha != "" {
-                        // アルファベットとアンダーバーが混在する
-                    } else {
-                        // アンダーバーのみ
-                    }
-                } else if alpha != "" {
-                    // アルファベットのみ
-                } else {
-                    // 何もなし
-                }
-})
-    */
 pub fn many_alpha_s(s: &str) -> IResult<&str, String> {
-    let (no_used, parser) = tuple((many1(alpha1), many1(char('_'))))(s)?;
-    println!("parsed: {:?}", parser);
-
-    let mut result = String::new();
-
-    //for p in parser {
-    // 文字列部分
-    for i in parser.0 {
-        result.push_str(i);
-    }
-    for i in parser.1 {
-        result.push_str("_");
-    }
-    //}
-
-    println!("{}", result);
-
-    Ok((no_used, result.to_string()))
+    let (no_used, parser) = map(alt((tag("_"), alpha1, digit1)), |type_str| type_str)(s)?;
+    //let (no_used, parser) = tuple((many1(alpha1), many1(char('_'))))(s)?;
+    Ok((no_used, parser.to_string()))
 }
 
 // 文字列のパーサ

--- a/test.c
+++ b/test.c
@@ -1,0 +1,10 @@
+int main() {
+  return "he__h__";
+}
+int test() {
+  return "_h";
+}
+
+int test() {
+  return "_h123";
+}

--- a/test.c
+++ b/test.c
@@ -1,10 +1,19 @@
 int main() {
   return "he__h__";
 }
-int test() {
-  return "_h";
-}
 
 int test() {
+  return "_h3";
+}
+
+int test2() {
   return "_h123";
+}
+
+int test3() {
+  return "_h12!";
+}
+
+int test_4() {
+  return "_h12!";
 }

--- a/test.c
+++ b/test.c
@@ -17,3 +17,6 @@ int test3() {
 int test_4() {
   return "_h12!";
 }
+
+int test_5() {
+}

--- a/test2.c
+++ b/test2.c
@@ -1,0 +1,5 @@
+int test() {
+  printf(1);
+  printf("HELLO, {}", a);
+  return 0;
+}


### PR DESCRIPTION
# クオートで囲った文字列のパースに対応

- 「"」で囲ったトークンをパースする処理を実装。
- 種類が異なるステートメントが連なる文において適切にパース処理が繰り返されない問題を解消。
- テストを実装。
- テストに使うファイルを実装。

## 実装

新規実装として、例えば以下のコードを正常にパースできる。

```
int test() {
  printf(1);
  printf("HELLO, {}", a);
  return 0;
}
```

以下のコマンドで正常実行を確認。

```
cargo test
```

```
cargo -- test.c
```

```
cargo -- test2.c
```
